### PR TITLE
Scaling of all data at export

### DIFF
--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -707,7 +707,7 @@ class DaeExporter:
         float_values = ""
         for v in vertices:
             float_values += " {} {} {}".format(
-                v.normal.x * FILESCALE, v.normal.y * FILESCALE, v.normal.z FILESCALE)
+                v.normal.x * FILESCALE, v.normal.y * FILESCALE, v.normal.z * FILESCALE)
         self.writel(
             S_GEOM, 4, "<float_array id=\"{}-normals-array\" "
             "count=\"{}\">{}</float_array>".format(

--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -707,7 +707,7 @@ class DaeExporter:
         float_values = ""
         for v in vertices:
             float_values += " {} {} {}".format(
-                v.normal.x, v.normal.y, v.normal.z)
+                v.normal.x * FILESCALE, v.normal.y * FILESCALE, v.normal.z FILESCALE)
         self.writel(
             S_GEOM, 4, "<float_array id=\"{}-normals-array\" "
             "count=\"{}\">{}</float_array>".format(

--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -49,6 +49,9 @@ S_ANIM = 12
 
 CMP_EPSILON = 0.0001
 
+FILESCALE = 70
+UTILMATRIX = Matrix([[0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,FILESCALE-1]])
+
 
 def snap_tup(tup):
     ret = ()
@@ -1132,7 +1135,7 @@ class DaeExporter:
         if (is_ctrl_bone is False):
             self.writel(
                 S_NODES, il, "<matrix sid=\"transform\">{}</matrix>".format(
-                    strmtx(xform)))
+                    strmtx((xform * FILESCALE).normalized() - UTILMATRIX )))
 
         for c in bone.children:
             self.export_armature_bone(c, il, si)

--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -934,7 +934,7 @@ class DaeExporter:
                 contid))
             pose_values = ""
             for v in si["bone_bind_poses"]:
-                pose_values += " {}".format(strmtx(v))
+                pose_values += " {}".format(strmtx((v * FILESCALE).normalized() - UTILMATRIX))
 
             self.writel(
                 S_SKIN, 4, "<float_array id=\"{}-bind_poses-array\" "

--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -1556,7 +1556,7 @@ class DaeExporter:
         for k in keys:
             source_frames += " {}".format(k[0])
             if (matrices):
-                source_transforms += " {}".format(strmtx(k[1]))
+                source_transforms += " {}".format(strmtx((k[1] * FILESCALE).normalized() - UTILMATRIX))
             else:
                 source_transforms += " {}".format(k[1])
 


### PR DESCRIPTION
Here's the first working result of scaling the exported data by a chosen factor. Right now it's hard-coded to 70 to enable a good workflow between Blender and OpenMW (1:70 scale).

Might need scaling applied in a few other places, but it currently works with the OpenMWDude file.