### PR TITLE
Option to export textkeys into a file

### DIFF
--- a/io_scene_dae/__init__.py
+++ b/io_scene_dae/__init__.py
@@ -70,74 +70,84 @@ class CE_OT_export_dae(bpy.types.Operator, ExportHelper):
                     "layers if that applies).",
         default=False,
         )
+        
     use_mesh_modifiers : BoolProperty(
         name="Apply Modifiers",
         description="Apply modifiers to mesh objects (on a copy!).",
         default=True,
         )
+        
     use_exclude_armature_modifier : BoolProperty(
         name="Exclude Armature Modifier",
         description="Exclude the armature modifier when applying modifiers "
                       "(otherwise animation will be applied on top of the last pose)",
         default=True,
         )
+        
     use_tangent_arrays : BoolProperty(
         name="Tangent Arrays",
         description="Export Tangent and Binormal arrays "
                     "(for normalmapping).",
         default=False,
         )
+        
     use_triangles : BoolProperty(
         name="Triangulate",
         description="Export Triangles instead of Polygons.",
         default=True,
         )
-
+        
     use_copy_images : BoolProperty(
         name="Copy Images",
         description="Copy Images (create images/ subfolder)",
         default=False,
         )
+        
     use_active_layers : BoolProperty(
         name="Active Layers",
         description="Export only objects on the active layers.",
         default=True,
         )
+        
     use_exclude_ctrl_bones : BoolProperty(
         name="Exclude Control Bones",
         description=("Exclude skeleton bones with names beginning with 'ctrl' "
                      "or bones which are not marked as Deform bones."),
         default=True,
         )
+        
     use_anim : BoolProperty(
         name="Export Animation",
         description="Export keyframe animation",
         default=True,
         )
+        
     use_anim_action_all : BoolProperty(
         name="All Actions",
         description=("Export all actions for the first armature found "
                      "in separate DAE files"),
         default=True,
         )
+        
     use_anim_skip_noexp : BoolProperty(
         name="Skip (-noexp) Actions",
         description="Skip exporting of actions whose name end in (-noexp)."
                     " Useful to skip control animations.",
         default=True,
         )
+        
     use_anim_optimize : BoolProperty(
         name="Optimize Keyframes",
         description="Remove double keyframes",
         default=True,
         )
-
+        
     use_shape_key_export : BoolProperty(
         name="Shape Keys",
         description="Export shape keys for selected objects.",
         default=False,
         )
-		
+        
     anim_optimize_precision : FloatProperty(
         name="Precision",
         description=("Tolerence for comparing double keyframes "
@@ -146,19 +156,26 @@ class CE_OT_export_dae(bpy.types.Operator, ExportHelper):
         soft_min=1, soft_max=16,
         default=6.0,
         )
-
+        
     use_metadata : BoolProperty(
         name="Use Metadata",
         default=True,
         options={"HIDDEN"},
         )
-    
+        
     scale_factor: FloatProperty(
         name="Scale",
         description="Scale all data",
         min=0.01, max=1000.0,
         default=1.0,
         )
+        
+    use_textkeys : BoolProperty(
+        name="Export Textkeys",
+        description=("Export a textkeys file based on timeline markers."
+                     " Needed to define animations for OpenMW."),
+        default=False,
+        )    
 
     @property
     def check_extension(self):

--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -55,7 +55,6 @@ def snap_tup(tup):
     ret = ()
     for x in tup:
         ret += (x - math.fmod(x, 0.0001), )
-
     return tup
 
 
@@ -1973,7 +1972,34 @@ class DaeExporter:
         else:
             self.export_animation(self.scene.frame_start, self.scene.frame_end)
 
-        self.writel(S_ANIM, 0, "</library_animations>")
+        self.writel(S_ANIM, 0, "</library_animations>")    
+    
+    def export_textkeys(self, filepath):
+        """
+        Writes a .txt file containing textkeys,
+        which are animation definitions
+        needed by the OpenMW game engine.
+        """
+        context = bpy.context
+        scene = context.scene    
+        textkeys_output = open(filepath[:-3] + "txt", "w")
+        
+        if not scene.timeline_markers:
+            textkeys_output.write("No timeline markers, needed to create textkeys, found in .blend file!")        
+            textkeys_output.close()  
+        
+        def sort_by_frame(item):
+            return item.frame    
+        
+        markers = []
+        for m in scene.timeline_markers:
+            markers.append(m)        
+        markers.sort(key=sort_by_frame)
+        
+        for m in markers:
+            tkf = round(m.frame * 1/scene.render.fps, 6)
+            textkeys_output.write(m.name + " " + str(tkf) + '\n' )        
+        textkeys_output.close()  
 
     def export(self):
         self.writel(S_GEOM, 0, "<library_geometries>")
@@ -2011,6 +2037,9 @@ class DaeExporter:
 
         if (self.config["use_anim"]):
             self.export_animations()
+        
+        if (self.config["use_textkeys"]):
+            self.export_textkeys(self.path)
 
         try:
             f = open(self.path, "wb")


### PR DESCRIPTION
Add an option when exporting the .dae file, it also exports the textkeys as needed by OpenMW. It's a .txt file with lines of what animation starts / ends / loops happens along with other events like sounds etc. Textkeys are created from timeline markers which need to be named in a way to allow the output to work for textkeys purposes. Frame numbers are added automatically.