### PR TITLE
Option to limit precision of exported data

### DIFF
--- a/io_scene_dae/__init__.py
+++ b/io_scene_dae/__init__.py
@@ -163,20 +163,20 @@ class CE_OT_export_dae(bpy.types.Operator, ExportHelper):
         options={"HIDDEN"},
         )
         
-    scale_factor : FloatProperty(
+    scale_factor: FloatProperty(
         name="Scale",
         description="Scale all data",
         min=0.01, max=1000.0,
         default=1.0,
         )
-            
+        
     use_textkeys : BoolProperty(
         name="Export Textkeys",
         description=("Export a textkeys file based on timeline markers."
                      " Needed to define animations for OpenMW."),
         default=False,
-        )
-        
+        )    
+
     use_limit_precision : IntProperty(
         name="Data Precision",
         description=("To how many decimals are the exported values limited. \n"
@@ -347,17 +347,16 @@ class DAE_PT_export_animation(bpy.types.Panel):
         layout.use_property_decorate = False
         
         sfile = context.space_data
-        operator = sfile.active_operator   
-
-        layout.enabled = operator.use_anim
-        col = layout.column(align = True) 
+        operator = sfile.active_operator
+        
+        layout.enabled = operator.use_anim     
+        col = layout.column(align = True)
         col.prop(operator, 'use_anim_action_all')
         col.prop(operator, 'use_anim_skip_noexp')
         col.prop(operator, 'use_anim_optimize')
         col.prop(operator, 'anim_optimize_precision')
-
-
-class DAE_PT_export_extras(bpy.types.Panel):
+ 
+ class DAE_PT_export_extras(bpy.types.Panel):
     bl_space_type = 'FILE_BROWSER'
     bl_region_type = 'TOOL_PROPS'
     bl_label = "Extra"
@@ -381,7 +380,6 @@ class DAE_PT_export_extras(bpy.types.Panel):
           
         col = layout.column(align = True)
         col.prop(operator, 'use_limit_precision')
-
     
 classes = (
     CE_OT_export_dae,

--- a/io_scene_dae/__init__.py
+++ b/io_scene_dae/__init__.py
@@ -356,7 +356,7 @@ class DAE_PT_export_animation(bpy.types.Panel):
         col.prop(operator, 'use_anim_optimize')
         col.prop(operator, 'anim_optimize_precision')
  
- class DAE_PT_export_extras(bpy.types.Panel):
+class DAE_PT_export_extras(bpy.types.Panel):
     bl_space_type = 'FILE_BROWSER'
     bl_region_type = 'TOOL_PROPS'
     bl_label = "Extra"

--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -846,9 +846,9 @@ class DaeExporter:
             float_values = ""
             for v in vertices:
                 float_values += " {} {} {}".format(
-                    round(v.bitangent.x, 6),
-                    round(v.bitangent.y, 6),
-                    round(v.bitangent.z, 6))
+                    round(v.bitangent.x, lim),
+                    round(v.bitangent.y, lim),
+                    round(v.bitangent.z, lim))
             self.writel(
                 S_GEOM, 4, "<float_array id=\"{}-bitangents-array\" "
                 "count=\"{}\">{}</float_array>".format(


### PR DESCRIPTION
Limit decimals from the default 16 to any integer between 4 and 16. Not limiting the time values, as those create problems playing the animations.

The PR includes changes done to scaling code, as they affect the same lines. No idea why it detects the whole UI part of the exporter as changed?