### PR TITLE
Textkeys based on pose markers

### DIFF
--- a/io_scene_dae/__init__.py
+++ b/io_scene_dae/__init__.py
@@ -66,13 +66,13 @@ class CE_OT_export_dae(bpy.types.Operator, ExportHelper):
     use_export_selected : BoolProperty(
         name="Selected Objects",
         description="Export only selected objects (and visible in active "
-                    "layers if that applies).",
+                    "layers if that applies)",
         default=False,
         )
         
     use_mesh_modifiers : BoolProperty(
         name="Apply Modifiers",
-        description="Apply modifiers to mesh objects (on a copy!).",
+        description="Apply modifiers to mesh objects (on a copy!)",
         default=True,
         )
         
@@ -86,13 +86,13 @@ class CE_OT_export_dae(bpy.types.Operator, ExportHelper):
     use_tangent_arrays : BoolProperty(
         name="Tangent Arrays",
         description="Export Tangent and Binormal arrays "
-                    "(for normalmapping).",
+                    "(for normalmapping)",
         default=False,
         )
         
     use_triangles : BoolProperty(
         name="Triangulate",
-        description="Export Triangles instead of Polygons.",
+        description="Export Triangles instead of Polygons",
         default=True,
         )
         
@@ -104,7 +104,7 @@ class CE_OT_export_dae(bpy.types.Operator, ExportHelper):
         
     use_active_layers : BoolProperty(
         name="Active Layers",
-        description="Export only objects on the active layers.",
+        description="Export only objects on the active layers",
         default=True,
         )
         
@@ -130,7 +130,7 @@ class CE_OT_export_dae(bpy.types.Operator, ExportHelper):
     use_anim_skip_noexp : BoolProperty(
         name="Skip (-noexp) Actions",
         description="Skip exporting of actions whose name end in (-noexp)."
-                    " Useful to skip control animations.",
+                    " Useful to skip control animations",
         default=True,
         )
         
@@ -142,7 +142,7 @@ class CE_OT_export_dae(bpy.types.Operator, ExportHelper):
         
     use_shape_key_export : BoolProperty(
         name="Shape Keys",
-        description="Export shape keys for selected objects.",
+        description="Export shape keys for selected objects",
         default=False,
         )
         
@@ -170,11 +170,11 @@ class CE_OT_export_dae(bpy.types.Operator, ExportHelper):
         
     use_textkeys : BoolProperty(
         name="Export Textkeys",
-        description=("Export a textkeys file based on timeline markers."
-                     " Needed to define animations for OpenMW."),
+        description=("Export a textkeys file based on pose markers in each exported action."
+                     " Needed to define animations for OpenMW"),
         default=False,
         )
-        
+       
     anim_source : EnumProperty(
         name="Animation Source",
         items=(("SCENE", "Timeline",
@@ -252,7 +252,7 @@ class DAE_PT_export_include(bpy.types.Panel):
         
         col = layout.column(heading = "Extras", align = True)
         col.prop(operator, 'use_copy_images')
-        col.prop(operator, 'use_textkeys')        
+        col.prop(operator, 'use_textkeys')
 
 class DAE_PT_export_transform(bpy.types.Panel):
     bl_space_type = 'FILE_BROWSER'
@@ -404,7 +404,6 @@ classes = (
     DAE_PT_export_armature,
     DAE_PT_export_animation,
     DAE_PT_export_extras
-
 )
 
 def register():  

--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -2087,13 +2087,14 @@ class DaeExporter:
         strips_cache = []
         
         # Gather all relevant strips
-        for track in bpy.data.objects['rig'].animation_data.nla_tracks:
-            if track.mute:
-                continue
-            for strip in track.strips:
-                if strip.mute:
+        for s in self.skeletons:
+            for track in s.animation_data.nla_tracks:
+                if track.mute:
                     continue
-                strips_cache.append(strip)
+                for strip in track.strips:
+                    if strip.mute:
+                        continue
+                    strips_cache.append(strip)
         
         # Gather all relevant markers
         for s in sorted(strips_cache, key=lambda x: x.frame_start):        

--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -2083,24 +2083,33 @@ class DaeExporter:
         context = bpy.context
         scene = context.scene
         textkeys_output = open(filepath[:-3] + "txt", "w")
-        
-        if not scene.timeline_markers:
-            textkeys_output.write("No timeline markers, needed to create textkeys, found in .blend file!")        
-            textkeys_output.close()  
-        
-        def sort_by_frame(item):
-            return item.frame    
-        
-        markers = []
-        for m in scene.timeline_markers:
-            markers.append(m)        
-        markers.sort(key=sort_by_frame)
-        
         lim = self.config["use_limit_precision"]
+        markers = []
+        strips_cache = []
+        
+        # Gather all relevant strips
+        for track in bpy.data.objects['rig'].animation_data.nla_tracks:
+            if track.mute:
+                continue
+            for strip in track.strips:
+                if strip.mute:
+                    continue
+                strips_cache.append(strip)
+        
+        # Gather all relevant markers
+        for s in sorted(strips_cache, key=lambda x: x.frame_start):        
+            for m in sorted(s.action.pose_markers, key=lambda x: x.frame):
+                # Frame offset based on the parent strip scale and
+                # position in the NLA editor.
+                frame = (m.frame * s.scale
+                        - (s.scale - 1)
+                        + s.frame_start - 1)
+                frame = round(frame * 1/scene.render.fps, lim)
+                markers.append(("{} {}").format(str(m.name), str(frame)))
+
         for m in markers:
-            tkf = round(m.frame * 1/scene.render.fps, lim)
-            textkeys_output.write(m.name + " " + str(tkf) + '\n' )        
-        textkeys_output.close()  
+            textkeys_output.write(m + '\n')        
+        textkeys_output.close()
 
     def export(self):
         self.writel(S_GEOM, 0, "<library_geometries>")

--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -2083,7 +2083,6 @@ class DaeExporter:
         context = bpy.context
         scene = context.scene
         textkeys_output = open(filepath[:-3] + "txt", "w")
-        lim = self.config["use_limit_precision"]
         markers = []
         strips_cache = []
         
@@ -2104,7 +2103,7 @@ class DaeExporter:
                 frame = (m.frame * s.scale
                         - (s.scale - 1)
                         + s.frame_start - 1)
-                frame = round(frame * 1/scene.render.fps, lim)
+                frame = frame * 1/scene.render.fps
                 markers.append(("{} {}").format(str(m.name), str(frame)))
 
         for m in markers:


### PR DESCRIPTION
Instead of basing the exported textkeys file on timeline markers, have them be based on pose markers which are in Blender contained per action.

The problem with timeline markers is that they are not connected to the NLA strips (actions added to the NLA editor) but need to be synchronized manually. Any time a NLA strip is moved, changed, or rearranged, the timeline markers relevant to this and other affected strips need to be adjusted.

It didn't cause a lot of problems with the Land Racer as that one has a limited number of animations and timeline markers. However now that the player animations are in the works, there's almost 800 different textkeys that need to be written (meaning 800 timeline markers). This would soon become unwieldy and cause unnecessary work. Below is a comparison of how the NLA editor looks with timeline markers (top) vs pose marker (bottom). 
![markers_compare](https://user-images.githubusercontent.com/3763179/159122087-461604a9-bb45-4b90-bec3-7b43b063d244.png)
So far it's a draft as the rig object holding the animations and pose markers is hard-coded. Documentation and example files will need to be updated as well before along with this change.

