### PR TITLE
Material export now based on Specular BSDF

### DIFF
--- a/io_scene_dae/export_dae.py
+++ b/io_scene_dae/export_dae.py
@@ -402,15 +402,17 @@ class DaeExporter:
         self.writel(S_FX, 5, "</reflective>")
 
 
-        # TRANSPARENCY STUFF ---------------------------------------------------
+        # TRANSPARENCY ---------------------------------------------------------
         # ----------------------------------------------------------------------
         if material.blend_method == "BLEND":
             self.writel(S_FX, 5, "<transparency>")
-            self.writel(S_FX, 6, "<float>{}</float>".format(material.alpha_threshold))
+            self.writel(S_FX, 6, "<float>{}</float>".format(
+                1 - shader.inputs[4].default_value))
             self.writel(S_FX, 5, "</transparency>")
 
         if material.blend_method == "CLIP":
-            self.alphatesting_materialdata = self.alphatesting_materialdata + " " + material.name + " " + str(material.alpha_threshold)
+            self.alphatesting_materialdata = (self.alphatesting_materialdata +
+                " " + material.name + " " + str(1 - shader.inputs[4].default_value))
 
 
         # INDEX OF REFRACTION --------------------------------------------------


### PR DESCRIPTION
Until now the exporter took the "Principles BSDF" shader node of the active material and used that to write COLLADA material values. It was only half working, as the principled shader is meant for PBR and its values don't match what COLLADA supports. Due to that, quite a few of the exported values were hard-coded and not exposed to the user.

This change makes it so that the "Specular BSDF" shader node and its values are used instead. The textures also work (though for OpenMW only the diffuse slot needs to be taken). Haven't done extensive testing yet.

Solves 1. issue in https://github.com/OpenMW/collada-exporter/issues/12